### PR TITLE
Remove extra character

### DIFF
--- a/config/job-template-example.json
+++ b/config/job-template-example.json
@@ -29,4 +29,4 @@
   ,"endTime":""
   ,"duration":""
 
-}d
+}


### PR DESCRIPTION
This was causing an exception when running `script/server`:

```
SyntaxError: /Users/tcbyrd/key2pdf/config/job-template.json: Unexpected token d in JSON at position 649
```