### PR TITLE
Cmd line shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 log/
+output/
 .env
 *.log
 log.json

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -13,6 +13,16 @@ var cleanup = function() {};
 
 cleanup.prototype.cleanup = function(job)
 {
+    if(!job.config.commitAfterConvert)
+    {
+        exec("cp ./job/" + job.jobID + "/*.pdf ./output/" + job.jobID, function (error, stdout, stderr) {
+            if (error !== null) {
+                logger.log('Error writing out base64: ' + error, job);
+                logger.log('stdout: ' + stdout, job);
+                logger.log('stderr: ' + stderr, job);
+            }
+        });
+    }
     if (job.config.deleteTempDir) {
         exec("rm -rf " + job.tempDir, function (error, stdout, stderr) {
             if (error !== null) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,10 @@
  */
 
 var format = require('date-fns/format');  //https://github.com/date-fns/date-fns
+var fs = require('fs');
 
+//replace with standard library
+//https://www.loggly.com/ultimate-guide/node-logging-basics/
 
 
 var logger = function() {};
@@ -26,5 +29,33 @@ logger.prototype.log = function(msg, job, status, error) {
     }
     console.log(datestamp + ":    " + msg);
 };
+
+logger.prototype.syslog = function(msg, status, error)
+{
+    var datestamp = format(new Date());
+    var logString = datestamp + ":\t" + status + "\t\t " + msg +  (error ? error : "");
+    console.log("SYSLOG: " + logString);
+    if(fs.existsSync('./log/key2pdf.log'))
+    {
+        fs.appendFile('./log/key2pdf.log', "\n"+logString, function(err)
+        {
+            if(err)
+            {
+                console.log("Error appending to SYSLOG: " + err)
+            }
+        });
+    }
+    else
+    {
+        fs.writeFile("./log/key2pdf.log", logString, function(err)
+        {
+            if(err)
+            {
+                console.log("Error writing to SYSLOG: " + err)
+            }
+        });
+    }
+
+}
 
 module.exports = new logger();

--- a/package.json
+++ b/package.json
@@ -24,19 +24,20 @@
   "homepage": "https://github.com/bryancross/key2pdf#readme",
   "dependencies": {
     "bluebird": "^3.4.7",
+    "cli-spinner": "^0.2.5",
     "cloudconvert": "^1.1.1",
     "date-fns": "^1.24.0",
     "github": "^7.2.1",
     "github-webhook-handler": "^0.6.0",
+    "google-auth-library": "^0.10.0",
+    "googleapis": "^16.1.0",
     "httpdispatcher": "^2.0.1",
     "js-base64": "^2.1.9",
     "mkdirp": "^0.5.1",
     "node-github": "0.0.3",
+    "request": "^2.79.0",
     "rimraf": "^2.5.4",
     "tmp": "0.0.31",
-    "cli-spinner": "^0.2.5",
-    "google-auth-library": "^0.10.0",
-    "googleapis": "^16.1.0",
-    "request": "^2.79.0"
+    "url-parse": "^1.1.8"
   }
 }

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -4,6 +4,8 @@ echo "creating log directory"
 mkdir -p log
 echo "Creating jobs directory"
 mkdir -p jobs
+echo "Creating output directory"
+mkdir -p output
 cp config/job-template-example.json config/job-template.json
 echo "Remember to edit config/job-template.json and, optionally,"
 echo "test/test-params.json with correct default values"

--- a/script/key2pdf.sh
+++ b/script/key2pdf.sh
@@ -41,14 +41,14 @@
 #/
 #/     key2pdf start
 #/
-#/#/  Stop the key2pdf server:
+#/  Stop the key2pdf server:
 #/
 #/      key2pdf stop
 #/
 #/  Convert a single Keynote file.   Output PDF will be copied to /output,
 #/  overwriting any files with the same name:
 #/
-#/      key2pdf --convert-file http://github.com/bryancross/testrepo/deck2.key
+#/      key2pdf --convert-file http://github.com/anorg/repo/blob/master/deck2.key
 #/
 #/  Convert a single Keynote file.   Output PDF will be committed to the source
 #/  repository in the same location and on the same branch as the source Keynote:

--- a/script/key2pdf.sh
+++ b/script/key2pdf.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+#/ Usage: key2pdf.sh cmd <option> <flags>
+#/
+#/ <DESCRIPTION>
+#/
+#/ CONFIGURATION VARIABLES (set in ./config/job-template.json):
+#/
+#/  VAR                       DESC
+#/
+#/ OPTIONS:
+#/  start	Start the key2pdf server
+#/
+#/  stop	Stop the key2pdf server
+#/
+#/  process-webhooks	    If present, key2pdf will respond to webhooks on the
+#/                          /pushhook endpoint
+#/
+#/  param-file              Path to a JSON file containing one or more keys
+#/                          whose values will overwrite matching keys in
+#/                          job-template.json
+#/
+#/  keynote_url             URL to a single Keynote file to be converted
+#/
+#/  repository_url          URL to a repository. All keynotes found in the
+#/                          repository on the specified branch will be converted
+#/
+#/  commit-after-convert    If present, converted PDF files will be committed to
+#/                          the source repo in the same location and on the
+#/                          same branch as the source Keynote
+#/
+#/  copy-to-gdrive          If present, converted PDF files will be uploaded to
+#/                          Google Drive
+#/
+#/  branch                  If present, key2pdf will search for the the
+#/                          specified Keynote file(s) on the specified branch.
+#/                          If not present, key2pdf will use the default branch
+#/                          for the repository
+#/
+#/ EXAMPLES:
+#/
+#/  Start the key2pdf server.  Do not respond to webhook events.  Useful for
+#/  testing.
+#/
+#/     key2pdf start
+#/
+#/  Start the key2pdf server.  Do not respond to webhook events.  Provide a JSON
+#/  file containing configuration parameters to override defaults.
+#/
+#/     key2pdf start --param-file my-config.json
+#/
+#/  Start the key2pdf server and listen for webhook events:
+#/
+#/      key2pdf start process-webhooks
+#/
+#/  Stop the key2pdf server:
+#/
+#/      key2pdf stop
+#/
+#/  Convert a single Keynote file.   Output PDF will be copied to /output,
+#/  overwriting any files with the same name:
+#/
+#/      key2pdf --convert-file http://github.com/bryancross/testrepo/deck2.key
+#/
+#/  Convert a single Keynote file.   Output PDF will be committed to the source
+#/  repository in the same location and on the same branch as the source Keynote:
+#/
+#/      key2pdf --convert-file http://github.com/bryancross/testrepo/deck2.key --commit-after-convert
+#/
+#/  Convert a single Keynote file.   Converted PDF will be committed to the
+#/  source repository in the same location and on the same branch as the source
+#/  Keynote and copied to Google Drive:
+#/
+#/      key2pdf --convert-file http://github.com/bryancross/testrepo/deck2.key --commit-after-convert --copy-to-gdrive
+#/
+#/  Convert all Keynote files in a repository on the default branch.  Converted
+#/  PDFs will be copied to /output, overwriting any files with the same name:
+#/
+#/      key2pdf --convert-repo http://github.com/bryancross/testrepo
+#/
+#/  Convert all Keynote files in a repository on the default branch.  Converted
+#/  PDFs will be copied to /output, overwriting any files with the same name:
+#/
+#/      key2pdf --convert-repo http://github.com/bryancross/testrepo
+#/
+#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
+#/  will be copied to /output, overwriting any files with the same name:
+#/
+#/      key2pdf --convert-repo http://github.com/bryancross/testrepo --branch foo
+#/
+#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
+#/  will be committed to the source repository in the same location and on the
+#/  same branch as the source Keynote:
+#/
+#/      key2pdf --convert-repo http://github.com/bryancross/testrepo --commit-after-convert --branch foo
+#/
+#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
+#/  will be committed to the source repository in the same location and on the
+#/  same branch as the source Keynote and copied to Google Drive:
+#/
+#/      key2pdf --convert-repo http://github.com/bryancross/testrepo --commit-after-convert --copy-to-gdrive --branch foo
+#/
+#/
+CMD_JSON=""
+FLAG_JSON=""
+CMD_OPTION=0
+for word in $@
+do
+    #echo "Current word: "$word" N: "$#" dollar1: "$1
+     case "$word" in
+        convert-file|convert-repo)
+            CMD_JSON="{\"cmd\":\"${1}\","
+            shift
+            CMD_JSON=$CMD_JSON"\"option\":\"${1}\""
+            CMD_OPTION=1
+            continue
+            ;;
+
+        start|stop)
+            CMD_JSON="{\"cmd\":\"${1}\""
+            #continue
+            ;;
+        --branch)
+            shift
+            shift
+            CMD_JSON=$CMD_JSON",\"branch\":\"${1}\""
+            echo "The --branch option is not yet supported.  Check back later!"
+            echo $1" branch specified"
+            CMD_OPTION=1
+            continue
+            ;;
+        --commit-after-convert|--copy-to-gdrive)
+            FLAG_JSON=$FLAG_JSON",\"${word:2}\""
+            #continue
+            ;;
+        *)
+            #echo "CMD_OPTION: "$CMD_OPTION
+            if [ $CMD_OPTION -eq 0 ]; then
+                grep '^#/' <"$0" | cut -c 4-
+                echo
+                echo "Invalid argument: "$word
+                exit 1
+            else
+                CMD_OPTION=0
+            fi
+      esac
+done
+
+if [[ -z $FLAG_JSON ]]; then
+    CMD_JSON=$CMD_JSON"}"
+else
+    CMD_JSON=$CMD_JSON","
+    CMD_JSON=$CMD_JSON"\"flags\":[${FLAG_JSON:1}]}"
+fi
+#CMD_JSON="{\"args\":"$CMD_JSON"}"
+
+echo "CMD_JSON: "$CMD_JSON
+
+curl -X POST -d ${CMD_JSON} -H "Authorization: token ${USER_1_AUTH_TOKEN}" -H "User-Agent: key2pdf" -H 'Accept: application/vnd.github.v3.raw' http://localhost:3000/key2pdf
+
+exit 0
+


### PR DESCRIPTION
Created a command line shim in /scripts/key2pdf.sh.  Usage is documented in the script:

```bash
#/Usage:  key2pdf.sh cmd <url> <flags>
#/        key2pdf start
#/        key2pdf stop
#/        key2pdf convert-file <url> [--commit-after-convert] [--copy-to-gdrive]
#/        key2pdf convert-repo <url> [--commit-after-convert] [--copy-to-gdrive]
#/
#/  Convert a single keynote file to PDF, or all keynote files in a repository
#/  to PDF.  Optionally commit the converted PDFs back to GitHub and/or copy
#/  them to a configured location in Google Drive
#/
#/ COMMANDS:
#/
#/  start	Start the key2pdf server
#/
#/  stop	Stop the key2pdf server
#/
#/  convert-file            Convert a single file
#/
#/  convert-repo            Convert all files in a repository
#/
#/
#/ OPTIONS:
#/
#/  url                     URL to a single Keynote file to be converted, or
#/                          to a branch in a repository to be converted.
#/ FLAGS:
#/
#/  commit-after-convert    If present, converted PDF files will be committed to
#/                          the source repo in the same location and on the
#/                          same branch as the source Keynote
#/
#/  copy-to-gdrive          If present, converted PDF files will be uploaded to
#/                          Google Drive
#/
#/ EXAMPLES:
#/
#/  Start the key2pdf server.  Do not respond to webhook events.  Useful for
#/  testing.
#/
#/     key2pdf start
#/
#/  Stop the key2pdf server:
#/
#/      key2pdf stop
#/
#/  Convert a single Keynote file.   Output PDF will be copied to /output,
#/  overwriting any files with the same name:
#/
#/      key2pdf --convert-file http://github.com/anorg/repo/blob/master/deck2.key
#/
#/  Convert a single Keynote file.   Output PDF will be committed to the source
#/  repository in the same location and on the same branch as the source Keynote:
#/
#/      key2pdf --convert-file http://github.com/anorg/repo/blob/master/deck2.key --commit-after-convert
#/
#/  Convert a single Keynote file.   Converted PDF will be committed to the
#/  source repository in the same location and on the same branch as the source
#/  Keynote and copied to Google Drive:
#/
#/      key2pdf --convert-file http://github.com/anorg/repo/blob/master/deck2.key --commit-after-convert --copy-to-gdrive
#/
#/  Convert all Keynote files in a repository on the default branch.  Converted
#/  PDFs will be copied to /output, overwriting any files with the same name:
#/
#/      key2pdf --convert-repo http://github.com/anorg/repo
#/
#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
#/  will be copied to /output, overwriting any files with the same name:
#/
#/      key2pdf --convert-repo http://github.com/anorg/repo/tree/foo
#/
#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
#/  will be committed to the source repository in the same location and on the
#/  same branch as the source Keynote:
#/
#/      key2pdf --convert-repo http://github.com/anorg/repo/tree/foo --commit-after-convert
#/
#/  Convert all Keynote files in a repository on branch foo.  Converted PDFs
#/  will be committed to the source repository in the same location and on the
#/  same branch as the source Keynote and copied to Google Drive:
#/
#/      key2pdf --convert-repo http://github.com/anorg/repo/tree/foo --commit-after-convert --copy-to-gdrive
#/
#/
```bash